### PR TITLE
nginx truncated data from a huge response from ES

### DIFF
--- a/nginx_config/default.conf
+++ b/nginx_config/default.conf
@@ -8,6 +8,8 @@ server {
   location /api {
       rewrite ^/api/?(.*)$ /$1 break;
       proxy_pass http://elastalert:3030/;
+      proxy_http_version 1.1;
+      proxy_buffering off;
   }
 
   location /api-ws {


### PR DESCRIPTION
If ES returns huge response, Elastalert API server sends truncated data behind nginx proxy. This happens because by default nginx uses proxy_http_version 1.0 which doesn't support chunked response. Also proxy_buffering affects, which is enabled by default.