### PR TITLE
fix nginx crashed in offline mode

### DIFF
--- a/nginx_config/default.conf
+++ b/nginx_config/default.conf
@@ -21,8 +21,10 @@ server {
   }
 
   location /api-app/releases {
+      resolver 127.0.0.11;
+      set $releases_url https://api.github.com/repos/ServerCentral/praeco/releases;
       proxy_cache github_api_cache;
-      proxy_pass https://api.github.com/repos/johnsusek/praeco/releases;
+      proxy_pass $releases_url;
   }
 
   location / {


### PR DESCRIPTION
If Praeco works without Internet, nginx crashes because it can't resolve api.github.com. This PR solves that problem by forcing nginx to resolve api.github.com only when request appeared