### PR TITLE
Remove top level 'query' key if exists

### DIFF
--- a/src/components/ESChart.vue
+++ b/src/components/ESChart.vue
@@ -585,25 +585,23 @@ export default {
       let query = {
         query: {
           bool: {
-            must: [
-              {
-                query_string: { query: this.query }
-              },
-              {
-                range: {
-                  [this.timeField]: {
-                    lte,
-                    gte
+            filter: {
+              bool: {
+                must: this.query.concat([{
+                  range: {
+                    [this.timeField]: {
+                      lte,
+                      gte
+                    }
                   }
-                }
+                }])
               }
-            ]
+            }
           }
         },
         size: 0,
         aggs: this.aggs
       };
-
       this.loading = true;
       this.searchError = '';
 

--- a/src/components/config/ConfigCondition.vue
+++ b/src/components/config/ConfigCondition.vue
@@ -332,7 +332,7 @@
 
     <span class="pop-trigger" @click="popFilterVisible = true">
       <span v-if="queryString === defaultFilter">UNFILTERED</span>
-      <span v-else>WITH FILTER</span>
+      <span v-else>WITH FILTERS</span>
       <span v-if="queryString !== defaultFilter"> {{ queryString }}</span>
     </span>
 

--- a/src/components/config/ConfigQuery.vue
+++ b/src/components/config/ConfigQuery.vue
@@ -83,10 +83,10 @@ export default {
 
     manual: {
       get() {
-        return this.$store.state.config.query.manual;
+        return JSON.stringify(this.$store.state.config.query.manual);
       },
       set(value) {
-        this.$store.commit('config/query/UPDATE_MANUAL', value);
+        this.$store.commit('config/query/UPDATE_MANUAL', JSON.parse(value));
       }
     },
 


### PR DESCRIPTION
You'll be able to view multiple query as in https://github.com/Yelp/elastalert/issues/1468#issue-283664553

Array of filter represents as a string.

Resolves #251 