### PR TITLE
Convert defaultFilter to array

### DIFF
--- a/src/components/config/ConfigCondition.vue
+++ b/src/components/config/ConfigCondition.vue
@@ -1244,7 +1244,7 @@ export default {
     },
 
     defaultFilter() {
-      return `${this.timeField}:*`;
+      return [`${this.timeField}:*`];
     }
   },
 


### PR DESCRIPTION
Convert defaultFilter to array when creating new rule https://github.com/johnsusek/praeco/blob/master/src/components/ESChart.vue#L590