### PR TITLE
Allow base URL configuration at docker run time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY . .
 RUN npm run build
 RUN cp -r dist/* /var/www/html
 EXPOSE 8080
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ Edit `es_username` and `es_password` in `config/api.config.json` and `config/ela
 
 The praeco UI is served by an included nginx server (see Dockerfile). Configure it as you would any nginx project by editing the files in `nginx_config`. Then update your docker-compose.yml and add your certificate files (under webapp volumes). Another option is using a reverse proxy.
 
+#### How do I serve the praeco UI under a custom base path, i.e. `http://www.my-domain.com:8080/my-path/`
+
+Uncomment the declaration of the `VUE_APP_BASE_URL` environment variable in `docker-compose.yml` and define the path you want.
+```yaml
+    environment:
+      VUE_APP_BASE_URL: /my-path/
+```
+Uncomment the rewrite command in `nginx.config/default.conf` and define the same path as in teh environment variable above.
+```
+rewrite ^/my-path(/.*)$ $1 last;
+```
 #### How do I change the writeback index?
 
 Edit `config/elastalert.yaml` and `config/api.config.json` and change the writeback_index values.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     image: 'praecoapp/praeco'
     ports:
       - 8080:8080
+#    environment:
+#      VUE_APP_BASE_URL: /my-path/
     volumes:
       - ./public/praeco.config.json:/var/www/html/praeco.config.json
       - ./nginx_config/nginx.conf:/etc/nginx/nginx.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ ! -z "${VUE_APP_BASE_URL}" ]; then
+  echo "VUE_APP_BASE_URL=${VUE_APP_BASE_URL}"  > .env
+  npm run build
+  cp -r dist/* /var/www/html
+fi
+
+echo "Starting Nginx"
+nginx -g 'daemon off;'

--- a/nginx_config/default.conf
+++ b/nginx_config/default.conf
@@ -4,6 +4,7 @@ proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=github_api_cache:60m max_
 
 server {
   listen 8080;
+  #rewrite ^/my-path(/.*)$ $1 last;
 
   location /api {
       rewrite ^/api/?(.*)$ /$1 break;

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title>praeco</title>
-    <script src="/js/cron-ui.min.js"></script>
+    <script src="<%= BASE_URL %>js/cron-ui.min.js"></script>
   </head>
 
   <body>

--- a/src/main.js
+++ b/src/main.js
@@ -61,6 +61,7 @@ function startApp(config) {
 // First get the config from the server
 // In development this will be in /public and served by webpack
 // In prod it is linked into the docker container
+axios.defaults.baseURL = process.env.BASE_URL;
 axios
   .get('/praeco.config.json')
   .then(res => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 
 module.exports = {
+  publicPath: process.env.VUE_APP_BASE_URL ? process.env.VUE_APP_BASE_URL : '/',
   configureWebpack: {
     devtool: process.env.NODE_ENV === 'coverage' ? '#eval' : undefined,
     performance: {


### PR DESCRIPTION
This fixes #272 by allowing base URL configuration at docker run time.