### PR TITLE
Update RuleView.vue only string starting with _rules should replace

### DIFF
--- a/src/views/RuleView.vue
+++ b/src/views/RuleView.vue
@@ -341,7 +341,7 @@ export default {
     async move() {
       let newPath = await this.$store.dispatch('configs/moveConfig', {
         oldConfig: this.$store.getters['config/config'](),
-        newPath: this.moveDest.replace(/_rules/, ''),
+        newPath: this.moveDest.replace(/^_rules/, ''),
         type: 'rules'
       });
 


### PR DESCRIPTION
only string starting with _rules should be replaced with empty string. For example if we have folder under root Rules folder by name 'my_rules' it should be left intact and '_rules' should not be replaced.