### PR TITLE
Add restart policy for containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   elastalert:
     image: 'praecoapp/elastalert-server'
+    restart: unless-stopped
     ports:
       - 3030:3030
       - 3333:3333
@@ -16,6 +17,9 @@ services:
 
   webapp:
     image: 'praecoapp/praeco'
+    restart: unless-stopped
+    depends_on:
+      - elastalert
     ports:
       - 8080:8080
 #    environment:


### PR DESCRIPTION
The alerting service should restart with the host itself as it is critical in most use cases.