### PR TITLE
Fix smtpPort default from 25 to undefined

### DIFF
--- a/src/store/config/alert.js
+++ b/src/store/config/alert.js
@@ -144,7 +144,7 @@ function initialState() {
     bcc: '',
     smtpSsl: false,
     smtpHost: '',
-    smtpPort: null,
+    smtpPort: undefined,
     smtpAuthFile: '',
     smtpKeyFile: '',
     smtpCertFile: '',

--- a/src/store/config/alert.js
+++ b/src/store/config/alert.js
@@ -144,7 +144,7 @@ function initialState() {
     bcc: '',
     smtpSsl: false,
     smtpHost: '',
-    smtpPort: 25,
+    smtpPort: null,
     smtpAuthFile: '',
     smtpKeyFile: '',
     smtpCertFile: '',

--- a/src/store/config/index.js
+++ b/src/store/config/index.js
@@ -364,8 +364,6 @@ export default {
 
         if (config.smtp_port) {
           commit('alert/UPDATE_SMTP_PORT', config.smtp_port);
-        } else {
-          commit('alert/UPDATE_SMTP_PORT', 25);
         }
 
         commit('alert/UPDATE_SMTP_AUTH_FILE', config.smtp_auth_file);

--- a/tests/unit/specs/alert/ConfigYamlEmail.spec.js
+++ b/tests/unit/specs/alert/ConfigYamlEmail.spec.js
@@ -42,7 +42,6 @@ realert:
 smtp_auth_file: "auth_file"
 smtp_cert_file: "cert_file"
 smtp_key_file: "key_file"
-smtp_port: 25
 smtp_ssl: true
 terms_size: 50
 timeframe:


### PR DESCRIPTION
## Summary
Fix the default value of **SMTP Port** in the Email alert setting from 25 to ~~null~~ **undefined**.

## Why
The default value for `smtpPort` should not be set, as it may unexpectedly overwrite the base configuration of `smtp_port` and break existing alert operation.

Common settings such as `smtp_host` and `smtp_port` should be configured in `config.yaml` or `BaseRule.config`. Even if `smtp_port` is not set, the default value of 25 will be applied by ElastAlert, so there is no need to specify it explicitly in each alert rule.
