### PR TITLE
praecoのvue3追加対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "sass": "^1.97.3",
         "unplugin-auto-import": "^21.0.0",
         "unplugin-vue-components": "^31.0.0",
-        "vite": "^7.3.1",
+        "vite": "^8.0.1",
         "vitest": "^4.0.18",
         "vue-eslint-parser": "^10.4.0"
       }
@@ -122,6 +122,22 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -449,6 +465,64 @@
       "peerDependencies": {
         "vue": "^3.2.0"
       }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -1376,7 +1450,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1387,7 +1460,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1398,7 +1470,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1414,11 +1485,27 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@one-ini/wasm": {
@@ -1427,6 +1514,16 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
+      "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
@@ -1767,6 +1864,261 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
+      "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
+      "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
+      "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
+      "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
@@ -1775,9 +2127,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.58.0.tgz",
-      "integrity": "sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -1789,9 +2141,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.58.0.tgz",
-      "integrity": "sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -1803,9 +2155,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.58.0.tgz",
-      "integrity": "sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -1817,9 +2169,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.58.0.tgz",
-      "integrity": "sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -1831,9 +2183,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.58.0.tgz",
-      "integrity": "sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -1845,9 +2197,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.58.0.tgz",
-      "integrity": "sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -1859,9 +2211,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.58.0.tgz",
-      "integrity": "sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -1873,9 +2225,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.58.0.tgz",
-      "integrity": "sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -1887,9 +2239,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.58.0.tgz",
-      "integrity": "sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -1901,9 +2253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.58.0.tgz",
-      "integrity": "sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -1915,9 +2267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.58.0.tgz",
-      "integrity": "sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -1929,9 +2281,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.58.0.tgz",
-      "integrity": "sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -1943,9 +2295,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.58.0.tgz",
-      "integrity": "sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -1957,9 +2309,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.58.0.tgz",
-      "integrity": "sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1971,9 +2323,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.58.0.tgz",
-      "integrity": "sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -1985,9 +2337,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.58.0.tgz",
-      "integrity": "sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -1999,9 +2351,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.58.0.tgz",
-      "integrity": "sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -2013,9 +2365,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.58.0.tgz",
-      "integrity": "sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -2027,9 +2379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.58.0.tgz",
-      "integrity": "sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -2041,9 +2393,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.58.0.tgz",
-      "integrity": "sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -2055,9 +2407,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.58.0.tgz",
-      "integrity": "sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -2069,9 +2421,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.58.0.tgz",
-      "integrity": "sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -2083,9 +2435,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.58.0.tgz",
-      "integrity": "sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -2097,9 +2449,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.58.0.tgz",
-      "integrity": "sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -2111,9 +2463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.58.0.tgz",
-      "integrity": "sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -2137,6 +2489,25 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2282,43 +2653,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.0.18",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/@vitest/pretty-format": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
@@ -2426,6 +2760,33 @@
         "@vue-js-cron/core": "6.3.0"
       }
     },
+    "node_modules/@vue-macros/common": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
+      "integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-sfc": "^3.5.22",
+        "ast-kit": "^2.1.2",
+        "local-pkg": "^1.1.2",
+        "magic-string-ast": "^1.0.2",
+        "unplugin-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/vue-macros"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.2.25"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.4.0.tgz",
@@ -2486,6 +2847,24 @@
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.0.tgz",
+      "integrity": "sha512-/NZlS4WtGIB54DA/z10gzk+n/V7zaqSzYZOVlg2CfdnpIKdB61bd7JDIMxf/zrtX41zod8E2/bbEBoW/d7x70Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^8.1.0",
+        "birpc": "^2.6.1",
+        "hookable": "^5.5.3",
+        "perfect-debounce": "^2.0.0"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.0.tgz",
+      "integrity": "sha512-h8uCb4Qs8UT8VdTT5yjY6tOJ//qH7EpxToixR0xqejR55t5OdISIg7AJ7eBkhBs8iu1qG5gY3QQNN1DF1EelAA==",
       "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
@@ -2921,6 +3300,38 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-kit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+      "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/ast-walker-scope": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
+      "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "ast-kit": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3078,6 +3489,15 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/bl": {
@@ -3549,7 +3969,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/config-chain": {
@@ -4798,7 +5217,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -4872,7 +5290,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -5484,6 +5901,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -6381,6 +6804,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6481,6 +6916,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/listr2": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
@@ -6531,7 +7227,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
       "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.4",
@@ -6715,6 +7410,21 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magic-string-ast": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
+      "integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.19"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -6850,7 +7560,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
       "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -6863,14 +7572,12 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mlly/node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.1.8",
@@ -6901,6 +7608,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "license": "MIT"
     },
     "node_modules/mustache": {
@@ -7346,7 +8059,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pend": {
@@ -7354,6 +8066,12 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
     },
     "node_modules/performance-now": {
@@ -7373,7 +8091,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7396,7 +8113,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -7415,9 +8131,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7586,7 +8302,6 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
       "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7782,10 +8497,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
+      "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.120.0",
+        "@rolldown/pluginutils": "1.0.0-rc.10"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
+      "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
-      "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7799,31 +8555,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.58.0",
-        "@rollup/rollup-android-arm64": "4.58.0",
-        "@rollup/rollup-darwin-arm64": "4.58.0",
-        "@rollup/rollup-darwin-x64": "4.58.0",
-        "@rollup/rollup-freebsd-arm64": "4.58.0",
-        "@rollup/rollup-freebsd-x64": "4.58.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.58.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.58.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.58.0",
-        "@rollup/rollup-linux-arm64-musl": "4.58.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.58.0",
-        "@rollup/rollup-linux-loong64-musl": "4.58.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.58.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.58.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.58.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.58.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.58.0",
-        "@rollup/rollup-linux-x64-gnu": "4.58.0",
-        "@rollup/rollup-linux-x64-musl": "4.58.0",
-        "@rollup/rollup-openbsd-x64": "4.58.0",
-        "@rollup/rollup-openharmony-arm64": "4.58.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.58.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.58.0",
-        "@rollup/rollup-win32-x64-gnu": "4.58.0",
-        "@rollup/rollup-win32-x64-msvc": "4.58.0",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -7957,7 +8713,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -8673,7 +9428,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8915,7 +9669,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {
@@ -9067,7 +9820,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
       "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
@@ -9218,17 +9970,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
+      "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
+        "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.10",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -9245,9 +9996,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -9260,13 +10012,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -9366,6 +10121,118 @@
           "optional": true
         },
         "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -9473,18 +10340,111 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
-      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.4.tgz",
+      "integrity": "sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^6.6.4"
+        "@babel/generator": "^7.28.6",
+        "@vue-macros/common": "^3.1.1",
+        "@vue/devtools-api": "^8.0.6",
+        "ast-walker-scope": "^0.8.3",
+        "chokidar": "^5.0.0",
+        "json5": "^2.2.3",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "mlly": "^1.8.0",
+        "muggle-string": "^0.4.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "scule": "^1.3.0",
+        "tinyglobby": "^0.2.15",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1",
+        "yaml": "^2.8.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
+        "@pinia/colada": ">=0.21.2",
+        "@vue/compiler-sfc": "^3.5.17",
+        "pinia": "^3.0.4",
         "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@pinia/colada": {
+          "optional": true
+        },
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "pinia": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.0.tgz",
+      "integrity": "sha512-O44X57jjkLKbLEc4OgL/6fEPOOanRJU8kYpCE8qfKlV96RQZcdzrcLI5mxMuVRUeXhHKIHGhCpHacyCk0HyO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^8.1.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/vue-router/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/vue-router/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/vue-router/node_modules/unplugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/vuex": {
@@ -9542,7 +10502,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
@@ -9837,6 +10796,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "vue-json-pretty": "2.6.0",
         "vue-prism-component": "2.0.0",
         "vue-query-builder": "github:nsano-rururu/vue-query-builder#v0.6.1vue3",
-        "vue-router": "^.0.3",
+        "vue-router": "^5.0.3",
         "vuex": "^4.1.0",
         "zrender": "6.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "vue-json-pretty": "2.6.0",
         "vue-prism-component": "2.0.0",
         "vue-query-builder": "github:nsano-rururu/vue-query-builder#v0.6.1vue3",
-        "vue-router": "^4.6.4",
+        "vue-router": "^.0.3",
         "vuex": "^4.1.0",
         "zrender": "6.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vue-json-pretty": "2.6.0",
     "vue-prism-component": "2.0.0",
     "vue-query-builder": "github:nsano-rururu/vue-query-builder#v0.6.1vue3",
-    "vue-router": "^4.6.4",
+    "vue-router": "^5.0.3",
     "vuex": "^4.1.0",
     "zrender": "6.0.0",
     "@element-plus/icons-vue": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "sass": "^1.97.3",
     "unplugin-auto-import": "^21.0.0",
     "unplugin-vue-components": "^31.0.0",
-    "vite": "^7.3.1",
+    "vite": "^8.0.1",
     "vitest": "^4.0.18",
     "vue-eslint-parser": "^10.4.0"
   }

--- a/src/components/config/ConfigCondition.vue
+++ b/src/components/config/ConfigCondition.vue
@@ -47,344 +47,357 @@
       <Icon icon="question-circle" class="pop-when-help" />
     </a>
 
-    <el-popover
-      v-if="showPopCardinalityField"
-      v-model:visible="popCardinalityVisible"
-      :teleported="false"
-      :class="{ 'is-invalid': !popCardinalityValid }">
-      <template #reference>
-        <span class="pop-trigger">
-          <span>OF </span>
-          <span>{{ cardinalityField || 'select a field' }}</span>
-        </span>
-      </template>
-      <el-form ref="cardinalityField" :model="$store.state.config.match">
-        <el-form-item prop="cardinalityField" required>
-          <el-select
-            v-model="cardinalityField"
-            filterable
-            clearable
-            :teleported="false"
-            placeholder="Select field">
-            <el-option
-              v-for="field in Object.keys(fieldsForAgg)"
-              :key="field"
-              :label="field"
-              :value="field" />
-          </el-select>
-        </el-form-item>
-      </el-form>
-    </el-popover>
-
-    <el-popover v-if="showPopOf" v-model:visible="popOfVisible" :teleported="false" :class="{ 'is-invalid': !popOfValid }">
-      <template #reference>
-        <span class="pop-trigger">
-          <span>OF </span>
-          <span>{{ metricAggKey || 'select a field' }}</span>
-        </span>
-      </template>
-      <el-form ref="of" :model="$store.state.config.match">
-        <el-form-item prop="metricAggKey" required>
-          <el-select
-            v-model="metricAggKey"
-            filterable
-            clearable
-            :teleported="false"
-            placeholder="Select field"
-            @update:model-value="popOfVisible = false; validate();">
-            <el-option
-              v-for="field in Object.keys(numberFields)"
-              :key="field"
-              :label="field"
-              :value="field" />
-          </el-select>
-        </el-form-item>
-      </el-form>
-    </el-popover>
-
-    <el-popover v-if="showPopOver" v-model:visible="popOverVisible" :teleported="false" :class="{ 'is-invalid': !popOverValid }">
-      <template #reference>
-        <span class="pop-trigger">
-          <span>
-            <span v-if="groupedOver === 'field'">GROUPED </span>
-            <span>OVER </span>
+    <span v-if="showPopCardinalityField">
+      <el-popover
+        v-model:visible="popCardinalityVisible"
+        :teleported="false"
+        :class="{ 'is-invalid': !popCardinalityValid }">
+        <template #reference>
+          <span class="pop-trigger">
+            <span>OF </span>
+            <span>{{ cardinalityField || 'select a field' }}</span>
           </span>
-          <span v-if="groupedOver === 'all'">all documents</span>
-          <span v-if="groupedOver === 'field'">{{ queryKey }}</span>
-        </span>
-      </template>
-      <div>
-        <el-radio
-          id="groupedOverAll"
-          v-model="groupedOver"
-          value="all"
-          border
-          @change="changeGroupedOver">
-          All documents
-        </el-radio>
+        </template>
+        <el-form ref="cardinalityField" :model="$store.state.config.match">
+          <el-form-item prop="cardinalityField" required>
+            <el-select
+              v-model="cardinalityField"
+              filterable
+              clearable
+              :teleported="false"
+              placeholder="Select field">
+              <el-option
+                v-for="field in Object.keys(fieldsForAgg)"
+                :key="field"
+                :label="field"
+                :value="field" />
+            </el-select>
+          </el-form-item>
+        </el-form>
+      </el-popover>
+    </span>
 
-        <el-radio
-          id="groupedOverField"
-          v-model="groupedOver"
-          value="field"
-          border
-          @change="changeGroupedOver">
-          Field
-        </el-radio>
+    <span v-if="showPopOf">
+      <el-popover v-model:visible="popOfVisible" :teleported="false" :class="{ 'is-invalid': !popOfValid }">
+        <template #reference>
+          <span class="pop-trigger">
+            <span>OF </span>
+            <span>{{ metricAggKey || 'select a field' }}</span>
+          </span>
+        </template>
+        <el-form ref="of" :model="$store.state.config.match">
+          <el-form-item prop="metricAggKey" required>
+            <el-select
+              v-model="metricAggKey"
+              filterable
+              clearable
+              :teleported="false"
+              placeholder="Select field"
+              @update:model-value="popOfVisible = false; validate();">
+              <el-option
+                v-for="field in Object.keys(numberFields)"
+                :key="field"
+                :label="field"
+                :value="field" />
+            </el-select>
+          </el-form-item>
+        </el-form>
+      </el-popover>
+    </span>
 
-        <div v-if="groupedOver === 'all' && type === 'metric_aggregation'">
-          <el-form ref="overall" :model="$store.state.config.match">
-            <el-form-item label="" prop="docType" required>
-              <el-select
-                v-model="docType"
-                filterable
-                clearable
-                allow-create
-                class="el-select-wide m-n-sm"
-                placeholder="Select doc type"
-                @change="validate">
-                <el-option v-for="type2 in types" :key="type2" :label="type2" :value="type2" />
-              </el-select>
-            </el-form-item>
-          </el-form>
+    <span v-if="showPopOver">
+      <el-popover v-model:visible="popOverVisible" :teleported="false" :class="{ 'is-invalid': !popOverValid }">
+        <template #reference>
+          <span class="pop-trigger">
+            <span>
+              <span v-if="groupedOver === 'field'">GROUPED </span>
+              <span>OVER </span>
+            </span>
+            <span v-if="groupedOver === 'all'">all documents</span>
+            <span v-if="groupedOver === 'field'">{{ queryKey }}</span>
+          </span>
+        </template>
+        <div>
+          <el-radio
+            id="groupedOverAll"
+            v-model="groupedOver"
+            value="all"
+            border
+            @change="changeGroupedOver">
+            All documents
+          </el-radio>
+
+          <el-radio
+            id="groupedOverField"
+            v-model="groupedOver"
+            value="field"
+            border
+            @change="changeGroupedOver">
+            Field
+          </el-radio>
+
+          <div v-if="groupedOver === 'all' && type === 'metric_aggregation'">
+            <el-form ref="overall" :model="$store.state.config.match">
+              <el-form-item label="" prop="docType" required>
+                <el-select
+                  v-model="docType"
+                  filterable
+                  clearable
+                  allow-create
+                  class="el-select-wide m-n-sm"
+                  placeholder="Select doc type"
+                  @change="validate">
+                  <el-option v-for="type2 in types" :key="type2" :label="type2" :value="type2" />
+                </el-select>
+              </el-form-item>
+            </el-form>
+          </div>
+          <div v-if="groupedOver === 'field'">
+            <el-form ref="over" :model="$store.state.config.match">
+              <el-form-item
+                v-for="(entry, index2) in queryKey"
+                :key="index2"
+                :prop="`queryKey.${index2}`" required>
+                <el-select
+                  v-model="queryKey[index2]"
+                  filterable
+                  clearable
+                  placeholder="Select field"
+                  class="el-select-wide m-n-sm"
+                  style="width: 280px"
+                  :teleported="false">
+                  <el-option
+                    v-for="field in Object.keys(fieldsForAgg)"
+                    :key="field"
+                    :label="field"
+                    :value="field" />
+                </el-select>
+                <el-col :span="4">
+                  <el-button
+                    type="danger"
+                    circle
+                    plain
+                    @click="removeQueryKeyEntry(entry)">
+                    <el-icon><Delete /></el-icon>
+                  </el-button>
+                </el-col>
+              </el-form-item>
+            </el-form>
+
+            <el-button class="m-n-sm" @click="addQueryKeyEntry">
+              Add querykey
+            </el-button>
+          </div>
+
+          <label class="m-n-xs mini">
+            Grouping over a field changes the re-alert<br> behavior to apply on a per-group basis.
+          </label>
         </div>
-        <div v-if="groupedOver === 'field'">
-          <el-form ref="over" :model="$store.state.config.match">
-            <el-form-item
-              v-for="(entry, index2) in queryKey"
-              :key="index2"
-              :prop="`queryKey.${index2}`" required>
-              <el-select
-                v-model="queryKey[index2]"
-                filterable
-                clearable
-                placeholder="Select field"
-                class="el-select-wide m-n-sm"
-                style="width: 280px"
-                :teleported="false">
+      </el-popover>
+    </span>
+
+    <span v-if="showPopCompare">
+      <el-popover v-model:visible="popCompareVisible" :teleported="false" :class="{ 'is-invalid': !popCompareValid }">
+        <template #reference>
+          <span class="pop-trigger">
+            <template v-if="compareKey && compareKey.length > 1">
+              <span>FIELDS</span>
+              <span> {{ compareKey }}</span>
+            </template>
+            <template v-else-if="compareKey && compareKey.length === 1">
+              <span>FIELD</span>
+              <span> {{ compareKey[0] }}</span>
+            </template>
+            <template v-else>
+              <span>FIELD</span>
+              <span> {{ compareKey }}</span>
+            </template>
+          </span>
+        </template>
+        <el-form ref="compare" :model="$store.state.config.match">
+          <el-form-item prop="compareKey" required>
+            <el-select
+              v-model="compareKey"
+              :multiple="metricAggType === 'field changes'"
+              :filterable="metricAggType !== 'field changes'"
+              clearable
+              :teleported="false"
+              placeholder="Field"
+              style="width: 280px"
+              @update:model-value="popCompareVisible = false; validate();">
+              <template v-if="['field in list', 'field not in list'].includes(metricAggType)">
                 <el-option
-                  v-for="field in Object.keys(fieldsForAgg)"
+                  v-for="field in Object.keys(textFields)"
                   :key="field"
                   :label="field"
                   :value="field" />
-              </el-select>
-              <el-col :span="4">
-                <el-button
-                  type="danger"
-                  circle
-                  plain
-                  @click="removeQueryKeyEntry(entry)">
-                  <el-icon><Delete /></el-icon>
-                </el-button>
-              </el-col>
+              </template>
+              <template v-else>
+                <el-option
+                  v-for="field in Object.keys(fields)"
+                  :key="field"
+                  :label="field"
+                  :value="field" />
+              </template>
+            </el-select>
+            <label v-if="metricAggType === 'field changes'">The field to check for changes.</label>
+          </el-form-item>
+        </el-form>
+      </el-popover>
+    </span>
+
+    <span v-if="showPopGroup">
+      <el-popover v-model:visible="popGroupVisible" :teleported="false" :class="{ 'is-invalid': !popGroupValid }">
+        <template #reference>
+          <span class="pop-trigger" @click.stop="popGroupVisible = true">
+            <span>
+              <span v-if="metricAggType === 'new term'">IN FIELD </span>
+              <span v-else>GROUPED OVER </span>
+            </span>
+            <span>{{ queryKey }}</span>
+          </span>
+        </template>
+        <el-form ref="group" :model="$store.state.config.match">
+          <el-form-item
+            v-for="(entry, index2) in queryKey"
+            :key="index2"
+            :prop="`queryKey.${index2}`" required>
+            <el-select
+              v-model="queryKey[index2]"
+              filterable
+              clearable
+              :teleported="false"
+              placeholder="Select field"
+              class="el-select-wide"
+              style="width: 280px">
+              <el-option
+                v-for="field in Object.keys(fieldsForAgg)"
+                :key="field"
+                :label="field"
+                :value="field" />
+            </el-select>
+            <el-col :span="4">
+              <el-button
+                type="danger"
+                circle
+                plain
+                @click="removeQueryKeyEntry(entry)">
+                <el-icon><Delete /></el-icon>
+              </el-button>
+            </el-col>
+            <label v-if="metricAggType === 'field changes'">Field change will be checked per-group.</label>
+          </el-form-item>
+        </el-form>
+
+        <el-button class="m-n-sm" @click="addQueryKeyEntry">
+          Add querykey
+        </el-button>
+      </el-popover>
+    </span>
+
+    <span v-if="showPopBlacklist">
+      <el-popover v-model="popBlacklistVisible" :class="{ 'is-invalid': !popBlacklistValid }">
+        <template #reference>
+          <span class="pop-trigger">
+            <el-tooltip v-if="blacklist.length" :content="blacklist.join(', ')" placement="top">
+              <span>IN LIST ({{ blacklist.length }})</span>
+            </el-tooltip>
+            <span v-else>IN LIST ({{ blacklist.length }})</span>
+          </span>
+        </template>
+        <div>
+          <!-- native modifier has been removed, please confirm whether the function has been affected  -->
+          <el-form
+            ref="blacklist"
+            :model="$store.state.config.match"
+            label-position="top"
+            style="width: 360px"
+            @submit.prevent>
+            <el-form-item
+              v-for="(entry, index2) in blacklist"
+              :key="index2"
+              :prop="`blacklist.${index2}`"
+              class="el-form-item-list"
+              label=""
+              required>
+              <el-row :gutter="5" justify="space-between">
+                <el-col :span="20">
+                  <el-input
+                    v-model="blacklist[index2]"
+                    placeholder="Keyword"
+                    @update:model-value="(val) => updateBlacklist(val, index2)" />
+                </el-col>
+                <el-col :span="4">
+                  <el-button
+                    type="danger"
+                    circle
+                    plain
+                    @click="removeBlacklistEntry(entry)">
+                    <el-icon><Delete /></el-icon>
+                  </el-button>
+                </el-col>
+              </el-row>
             </el-form-item>
           </el-form>
 
-          <el-button class="m-n-sm" @click="addQueryKeyEntry">
-            Add querykey
+          <el-button class="m-n-sm" @click="addBlacklistEntry">
+            Add keyword
           </el-button>
         </div>
+      </el-popover>
+    </span>
 
-        <label class="m-n-xs mini">
-          Grouping over a field changes the re-alert<br> behavior to apply on a per-group basis.
-        </label>
-      </div>
-    </el-popover>
-
-    <el-popover v-if="showPopCompare" v-model:visible="popCompareVisible" :teleported="false" :class="{ 'is-invalid': !popCompareValid }">
-      <template #reference>
-        <span class="pop-trigger">
-          <template v-if="compareKey && compareKey.length > 1">
-            <span>FIELDS</span>
-            <span> {{ compareKey }}</span>
-          </template>
-          <template v-else-if="compareKey && compareKey.length === 1">
-            <span>FIELD</span>
-            <span> {{ compareKey[0] }}</span>
-          </template>
-          <template v-else>
-            <span>FIELD</span>
-            <span> {{ compareKey }}</span>
-          </template>
-        </span>
-      </template>
-      <el-form ref="compare" :model="$store.state.config.match">
-        <el-form-item prop="compareKey" required>
-          <el-select
-            v-model="compareKey"
-            :multiple="metricAggType === 'field changes'"
-            :filterable="metricAggType !== 'field changes'"
-            clearable
-            :teleported="false"
-            placeholder="Field"
-            style="width: 280px"
-            @update:model-value="popCompareVisible = false; validate();">
-            <template v-if="['field in list', 'field not in list'].includes(metricAggType)">
-              <el-option
-                v-for="field in Object.keys(textFields)"
-                :key="field"
-                :label="field"
-                :value="field" />
-            </template>
-            <template v-else>
-              <el-option
-                v-for="field in Object.keys(fields)"
-                :key="field"
-                :label="field"
-                :value="field" />
-            </template>
-          </el-select>
-          <label v-if="metricAggType === 'field changes'">The field to check for changes.</label>
-        </el-form-item>
-      </el-form>
-    </el-popover>
-
-    <el-popover v-if="showPopGroup" v-model:visible="popGroupVisible" :teleported="false" :class="{ 'is-invalid': !popGroupValid }">
-      <template #reference>
-        <span class="pop-trigger" @click.stop="popGroupVisible = true">
-          <span>
-            <span v-if="metricAggType === 'new term'">IN FIELD </span>
-            <span v-else>GROUPED OVER </span>
+    <span v-if="showPopWhitelist">
+      <el-popover v-model="popWhitelistVisible" :class="{ 'is-invalid': !popWhitelistValid }">
+        <template #reference>
+          <span class="pop-trigger">
+            <el-tooltip v-if="whitelist.length" :content="whitelist.join(', ')" placement="top">
+              <span>NOT IN LIST ({{ whitelist.length }})</span>
+            </el-tooltip>
+            <span v-else>NOT IN LIST ({{ whitelist.length }})</span>
           </span>
-          <span>{{ queryKey }}</span>
-        </span>
-      </template>
-      <el-form ref="group" :model="$store.state.config.match">
-        <el-form-item
-          v-for="(entry, index2) in queryKey"
-          :key="index2"
-          :prop="`queryKey.${index2}`" required>
-          <el-select
-            v-model="queryKey[index2]"
-            filterable
-            clearable
-            :teleported="false"
-            placeholder="Select field"
-            class="el-select-wide"
-            style="width: 280px">
-            <el-option
-              v-for="field in Object.keys(fieldsForAgg)"
-              :key="field"
-              :label="field"
-              :value="field" />
-          </el-select>
-          <el-col :span="4">
-            <el-button
-              type="danger"
-              circle
-              plain
-              @click="removeQueryKeyEntry(entry)">
-              <el-icon><Delete /></el-icon>
-            </el-button>
-          </el-col>
-          <label v-if="metricAggType === 'field changes'">Field change will be checked per-group.</label>
-        </el-form-item>
-      </el-form>
+        </template>
+        <div>
+          <!-- native modifier has been removed, please confirm whether the function has been affected  -->
+          <el-form
+            ref="whitelist"
+            :model="$store.state.config.match"
+            label-position="top"
+            style="width: 360px"
+            @submit.prevent>
+            <el-form-item
+              v-for="(entry, index2) in whitelist"
+              :key="index2"
+              :prop="`whitelist.${index}`"
+              required
+              class="el-form-item-list"
+              label="">
+              <el-row :gutter="5" justify="space-between">
+                <el-col :span="20">
+                  <el-input
+                    v-model="whitelist[index2]"
+                    placeholder="Keyword"
+                    @update:model-value="(val) => updateWhitelist(val, index2)" />
+                </el-col>
+                <el-col :span="4">
+                  <el-button
+                    type="danger"
+                    circle
+                    plain
+                    @click.prevent="removeWhitelistEntry(entry)">
+                    <el-icon><Delete /></el-icon>
+                  </el-button>
+                </el-col>
+              </el-row>
+            </el-form-item>
+          </el-form>
 
-      <el-button class="m-n-sm" @click="addQueryKeyEntry">
-        Add querykey
-      </el-button>
-    </el-popover>
-
-    <el-popover v-if="showPopBlacklist" v-model="popBlacklistVisible" :class="{ 'is-invalid': !popBlacklistValid }">
-      <template #reference>
-        <span class="pop-trigger">
-          <el-tooltip v-if="blacklist.length" :content="blacklist.join(', ')" placement="top">
-            <span>IN LIST ({{ blacklist.length }})</span>
-          </el-tooltip>
-          <span v-else>IN LIST ({{ blacklist.length }})</span>
-        </span>
-      </template>
-      <div>
-        <!-- native modifier has been removed, please confirm whether the function has been affected  -->
-        <el-form
-          ref="blacklist"
-          :model="$store.state.config.match"
-          label-position="top"
-          style="width: 360px"
-          @submit.prevent>
-          <el-form-item
-            v-for="(entry, index2) in blacklist"
-            :key="index2"
-            :prop="`blacklist.${index2}`"
-            class="el-form-item-list"
-            label=""
-            required>
-            <el-row :gutter="5" justify="space-between">
-              <el-col :span="20">
-                <el-input
-                  v-model="blacklist[index2]"
-                  placeholder="Keyword"
-                  @update:model-value="(val) => updateBlacklist(val, index2)" />
-              </el-col>
-              <el-col :span="4">
-                <el-button
-                  type="danger"
-                  circle
-                  plain
-                  @click="removeBlacklistEntry(entry)">
-                  <el-icon><Delete /></el-icon>
-                </el-button>
-              </el-col>
-            </el-row>
-          </el-form-item>
-        </el-form>
-
-        <el-button class="m-n-sm" @click="addBlacklistEntry">
-          Add keyword
-        </el-button>
-      </div>
-    </el-popover>
-
-    <el-popover v-if="showPopWhitelist" v-model="popWhitelistVisible" :class="{ 'is-invalid': !popWhitelistValid }">
-      <template #reference>
-        <span class="pop-trigger">
-          <el-tooltip v-if="whitelist.length" :content="whitelist.join(', ')" placement="top">
-            <span>NOT IN LIST ({{ whitelist.length }})</span>
-          </el-tooltip>
-          <span v-else>NOT IN LIST ({{ whitelist.length }})</span>
-        </span>
-      </template>
-      <div>
-        <!-- native modifier has been removed, please confirm whether the function has been affected  -->
-        <el-form
-          ref="whitelist"
-          :model="$store.state.config.match"
-          label-position="top"
-          style="width: 360px"
-          @submit.prevent>
-          <el-form-item
-            v-for="(entry, index2) in whitelist"
-            :key="index2"
-            :prop="`whitelist.${index}`"
-            required
-            class="el-form-item-list"
-            label="">
-            <el-row :gutter="5" justify="space-between">
-              <el-col :span="20">
-                <el-input
-                  v-model="whitelist[index2]"
-                  placeholder="Keyword"
-                  @update:model-value="(val) => updateWhitelist(val, index2)" />
-              </el-col>
-              <el-col :span="4">
-                <el-button
-                  type="danger"
-                  circle
-                  plain
-                  @click.prevent="removeWhitelistEntry(entry)">
-                  <el-icon><Delete /></el-icon>
-                </el-button>
-              </el-col>
-            </el-row>
-          </el-form-item>
-        </el-form>
-
-        <el-button class="m-n-sm" @click="addWhitelistEntry">
-          Add keyword
-        </el-button>
-      </div>
-    </el-popover>
+          <el-button class="m-n-sm" @click="addWhitelistEntry">
+            Add keyword
+          </el-button>
+        </div>
+      </el-popover>
+    </span>
 
     <span class="pop-trigger" @click="popFilterVisible = true">
       <span v-if="queryString === defaultFilter">UNFILTERED</span>
@@ -399,416 +412,423 @@
       <ConfigQuery ref="query" class="config-query" />
     </el-dialog>
 
-    <el-popover
-      v-if="showPopCardinalityThresholds"
-      v-model:visible="popCardinalityThresholdsVisible"
-      :teleported="false"
-      :class="{ 'is-invalid': !popCardinalityThresholdsValid }">
-      <template #reference>
-        <span class="pop-trigger">
-          <span>IS</span>
-          <span v-if="maxCardinality">
-            ABOVE {{ maxCardinality }}
+    <span v-if="showPopCardinalityThresholds">
+      <el-popover
+        v-model:visible="popCardinalityThresholdsVisible"
+        :teleported="false"
+        :class="{ 'is-invalid': !popCardinalityThresholdsValid }">
+        <template #reference>
+          <span class="pop-trigger">
+            <span>IS</span>
+            <span v-if="maxCardinality">
+              ABOVE {{ maxCardinality }}
+            </span>
+            <span v-if="minCardinality">
+              BELOW {{ minCardinality }}
+            </span>
           </span>
-          <span v-if="minCardinality">
-            BELOW {{ minCardinality }}
-          </span>
-        </span>
-      </template>
+        </template>
 
-      <el-row :gutter="10" style="width: 260px">
-        <el-col :span="10">
-          <el-select
-            id="cardinalityAboveOrBelow"
-            v-model="cardinalityAboveOrBelow"
-            class="el-select-wide"
-            @update:model-value="updateCardinalityAboveOrBelow">
-            <el-option key="above" label="Above" value="above" />
-            <el-option key="below" label="Below" value="below" />
-          </el-select>
-        </el-col>
-
-        <el-col :span="14">
-          <el-form ref="minMaxCardinality" :model="$store.state.config.match">
-            <el-form-item v-if="cardinalityAboveOrBelow === 'above'" prop="maxCardinality" required>
-              <el-input-number
-                id="maxCardinality"
-                v-model="maxCardinality"
-                :min="0"
-                class="el-input-wide"
-                @update:model-value="validate" />
-            </el-form-item>
-            <el-form-item v-else prop="minCardinality" required>
-              <el-input-number
-                id="minCardinality"
-                v-model="minCardinality"
-                :min="1"
-                class="el-input-wide"
-                @update:model-value="validate" />
-            </el-form-item>
-          </el-form>
-        </el-col>
-      </el-row>
-    </el-popover>
-
-    <el-popover v-if="showPopAbove" v-model="popAboveVisible" :teleported="false" :class="{ 'is-invalid': !popAboveValid }">
-      <template #reference>
-        <span v-if="spikeOrThreshold === 'is' || metricAggType !== 'count'" class="pop-trigger">
-          <span>IS</span>
-          <span v-if="numEvents || maxThreshold">
-            ABOVE {{ metricAggType === 'count' ? numEvents : maxThreshold }}
-          </span>
-          <span v-if="(numEvents && threshold) || (maxThreshold && minThreshold)">
-            &amp;
-          </span>
-          <span v-if="threshold || minThreshold">
-            BELOW {{ metricAggType === 'count' ? threshold : minThreshold }}
-          </span>
-        </span>
-
-        <span v-else-if="spikeOrThreshold === 'spike'" class="pop-trigger">
-          <span>SPIKES</span>
-          <span v-if="spikeType === 'up'">
-            UP
-          </span>
-          <span v-if="spikeType === 'down'">
-            DOWN
-          </span>
-          <span v-if="spikeType === 'both'">
-            EITHER DIRECTION
-          </span>
-          {{ spikeHeight }}x
-        </span>
-
-        <span v-else-if="spikeOrThreshold === 'any'" class="pop-trigger">
-          <span>IS NOT EMPTY</span>
-        </span>
-      </template>
-
-      <div v-if="metricAggType === 'count'">
-        <el-row :gutter="10" style="width: 360px">
-          <el-col :span="spikeOrThreshold === 'any' ? 24 : 8">
+        <el-row :gutter="10" style="width: 260px">
+          <el-col :span="10">
             <el-select
-              id="spikeOrThreshold"
-              v-model="spikeOrThreshold"
+              id="cardinalityAboveOrBelow"
+              v-model="cardinalityAboveOrBelow"
               class="el-select-wide"
-              :teleported="false">
-              <el-option key="any" label="Is not empty" value="any" />
-              <el-option key="is" label="Is" value="is" />
-              <el-option key="spike" label="Spikes" value="spike" />
-            </el-select>
-          </el-col>
-
-          <el-col v-if="spikeOrThreshold !== 'any'" :span="8">
-            <el-select
-              v-if="spikeOrThreshold === 'is'"
-              id="aboveOrBelow"
-              v-model="aboveOrBelow"
-              class="el-select-wide"
-              :teleported="false">
+              @update:model-value="updateCardinalityAboveOrBelow">
               <el-option key="above" label="Above" value="above" />
               <el-option key="below" label="Below" value="below" />
             </el-select>
-            <el-select v-else v-model="spikeType" class="el-select-wide">
-              <el-option label="Up" value="up" />
-              <el-option label="Down" value="down" />
-              <el-option label="Both" value="both" />
-            </el-select>
           </el-col>
 
-          <el-col v-if="spikeOrThreshold !== 'any'" :span="8">
-            <el-form ref="spikeOrThreshold" :model="$store.state.config.match">
-              <template v-if="spikeOrThreshold === 'is'">
-                <el-form-item v-if="aboveOrBelow === 'above'" prop="numEvents" required>
-                  <el-input-number
-                    id="numEvents"
-                    v-model="numEvents"
-                    :min="1"
-                    class="el-input-wide"
-                    @update:model-value="validate" />
-                </el-form-item>
-                <el-form-item v-else prop="threshold" required>
-                  <el-input-number
-                    id="threshold"
-                    v-model="threshold"
-                    :min="1"
-                    class="el-input-wide"
-                    @update:model-value="validate" />
-                </el-form-item>
-              </template>
-              <el-form-item v-else prop="spikeHeight" required>
+          <el-col :span="14">
+            <el-form ref="minMaxCardinality" :model="$store.state.config.match">
+              <el-form-item v-if="cardinalityAboveOrBelow === 'above'" prop="maxCardinality" required>
                 <el-input-number
-                  id="spikeHeight"
-                  v-model="spikeHeight"
+                  id="maxCardinality"
+                  v-model="maxCardinality"
+                  :min="0"
+                  class="el-input-wide"
+                  @update:model-value="validate" />
+              </el-form-item>
+              <el-form-item v-else prop="minCardinality" required>
+                <el-input-number
+                  id="minCardinality"
+                  v-model="minCardinality"
+                  :min="1"
                   class="el-input-wide"
                   @update:model-value="validate" />
               </el-form-item>
             </el-form>
           </el-col>
         </el-row>
-      </div>
-
-      <div v-else>
-        <el-form
-          ref="minMaxThreshold"
-          :rules="minMaxThresholdRules"
-          :model="$store.state.config.match"
-          label-width="60px">
-          <el-form-item label="Above" prop="maxThreshold">
-            <el-input-number id="maxThreshold" v-model="maxThreshold" :min="1" @change="validate" />
-          </el-form-item>
-          <el-form-item label="Below" prop="minThreshold">
-            <el-input-number id="minThreshold" v-model="minThreshold" :min="1" @change="validate" />
-          </el-form-item>
-        </el-form>
-      </div>
-    </el-popover>
-
-    <span v-show="showTime">
-      <el-popover
-        v-show="metricAggType === 'count' || metricAggType === 'field changes' || metricAggType === 'cardinality' || metricAggType === 'avg' || metricAggType === 'sum' || metricAggType === 'min' || metricAggType === 'max'"
-        popper-class="popover-time">
-        <template #reference>
-          <span class="pop-trigger">
-            <span>
-              <span v-if="metricAggType === 'field changes'">
-                WITHIN
-                <span v-if="!useTimeframe">ANY TIMEFRAME</span>
-              </span>
-              <span v-if="metricAggType === 'count' || metricAggType === 'cardinality' || metricAggType === 'avg' || metricAggType === 'sum' || metricAggType === 'min' || metricAggType === 'max'">FOR </span>
-              <span v-if="useTimeframe">THE LAST</span>
-            </span>
-            <ElastalertTimeView
-              v-if="useTimeframe"
-              :time="timeframe" />
-          </span>
-        </template>
-
-        <el-form v-if="metricAggType === 'field changes'" :class="{ 'm-s-lg': useTimeframe }">
-          <el-form-item label="Limit timeframe">
-            <el-switch v-model="useTimeframe" />
-            <label>
-              By default, the change rule type has no maximum time limit between changes.
-              Enable this option to check for a change within a limited time window.
-            </label>
-          </el-form-item>
-        </el-form>
-
-        <div v-if="useTimeframe">
-          <ElastalertTimePicker
-            id="timeframe"
-            :unit="Object.keys(timeframe)[0]"
-            :amount="Object.values(timeframe)[0]"
-            @update:model-value="updateTimeframe" />
-          <label v-if="metricAggType === 'field changes'">
-            The maximum time between changes.
-            After this time period, elastalert will forget the old
-            value of the {{ compareKey }} field.
-          </label>
-        </div>
-      </el-popover>
-
-      <el-popover v-show="showForTheLast">
-        <template #reference>
-          <span class="pop-trigger-pseudo">
-            <span>FOR THE LAST </span>
-            <ElastalertTimeView :time="bufferTime" />
-          </span>
-        </template>
       </el-popover>
     </span>
 
-    <el-popover
-      v-if="showOptions"
-      ref="optionsPop"
-      v-model="popOptionsVisible"
-      :class="{ 'is-invalid': !popOptionsValid }"
-      popper-class="popover-options">
-      <template #reference>
-        <span class="pop-trigger">
-          <span>WITH OPTIONS</span>
-        </span>
-      </template>
+    <span v-if="showPopAbove">
+      <el-popover v-model="popAboveVisible" :teleported="false" :class="{ 'is-invalid': !popAboveValid }">
+        <template #reference>
+          <span v-if="spikeOrThreshold === 'is' || metricAggType !== 'count'" class="pop-trigger">
+            <span>IS</span>
+            <span v-if="numEvents || maxThreshold">
+              ABOVE {{ metricAggType === 'count' ? numEvents : maxThreshold }}
+            </span>
+            <span v-if="(numEvents && threshold) || (maxThreshold && minThreshold)">
+              &amp;
+            </span>
+            <span v-if="threshold || minThreshold">
+              BELOW {{ metricAggType === 'count' ? threshold : minThreshold }}
+            </span>
+          </span>
 
-      <div v-if="metricAggType === 'field not in list' || metricAggType === 'field changes'">
-        <!-- native modifier has been removed, please confirm whether the function has been affected  -->
-        <el-form
-          ref="form"
-          :model="$store.state.config.match"
-          label-position="top"
-          @submit.prevent>
-          <el-form-item label="Ignore null">
-            <el-switch v-model="ignoreNull" />
-            <label>If set, events without the selected field will not match.</label>
-          </el-form-item>
-        </el-form>
-      </div>
+          <span v-else-if="spikeOrThreshold === 'spike'" class="pop-trigger">
+            <span>SPIKES</span>
+            <span v-if="spikeType === 'up'">
+              UP
+            </span>
+            <span v-if="spikeType === 'down'">
+              DOWN
+            </span>
+            <span v-if="spikeType === 'both'">
+              EITHER DIRECTION
+            </span>
+            {{ spikeHeight }}x
+          </span>
 
-      <div v-if="metricAggType === 'new term'">
-        <!-- native modifier has been removed, please confirm whether the function has been affected  -->
-        <el-form
-          ref="form"
-          :model="$store.state.config.match"
-          label-position="top"
-          @submit.prevent>
-          <el-form-item label="Terms window">
-            <ElastalertTimePicker
-              id="termsWindowSize"
-              :unit="Object.keys(termsWindowSize)[0]"
-              :amount="Object.values(termsWindowSize)[0]"
-              @update:model-value="updateTermsWindowSize" />
-            <label>
-              The amount of time used for the initial query to find existing terms.
-              No term that has occurred within this time frame will trigger an alert.
-              The default is 30 days.
-            </label>
-          </el-form-item>
+          <span v-else-if="spikeOrThreshold === 'any'" class="pop-trigger">
+            <span>IS NOT EMPTY</span>
+          </span>
+        </template>
 
-          <el-form-item label="Window step">
-            <ElastalertTimePicker
-              id="windowStepSize"
-              :unit="Object.keys(windowStepSize)[0]"
-              :amount="Object.values(windowStepSize)[0]"
-              @update:model-value="updateWindowStepSize" />
-            <label>
-              When querying for existing terms, split up the time range into steps of this size.
-              For example, using the default 30 day window size, and the default 1 day step size,
-              30 invidivdual queries will be made.
-              This helps to avoid timeouts for very expensive aggregation queries.
-              The default is 1 day.
-            </label>
-          </el-form-item>
+        <div v-if="metricAggType === 'count'">
+          <el-row :gutter="10" style="width: 360px">
+            <el-col :span="spikeOrThreshold === 'any' ? 24 : 8">
+              <el-select
+                id="spikeOrThreshold"
+                v-model="spikeOrThreshold"
+                class="el-select-wide"
+                :teleported="false">
+                <el-option key="any" label="Is not empty" value="any" />
+                <el-option key="is" label="Is" value="is" />
+                <el-option key="spike" label="Spikes" value="spike" />
+              </el-select>
+            </el-col>
 
-          <el-form-item label="Alert on missing field">
-            <el-switch v-model="alertOnMissingField" />
-            <label>Whether or not to alert when a field is missing from a document.</label>
-          </el-form-item>
-        </el-form>
-      </div>
+            <el-col v-if="spikeOrThreshold !== 'any'" :span="8">
+              <el-select
+                v-if="spikeOrThreshold === 'is'"
+                id="aboveOrBelow"
+                v-model="aboveOrBelow"
+                class="el-select-wide"
+                :teleported="false">
+                <el-option key="above" label="Above" value="above" />
+                <el-option key="below" label="Below" value="below" />
+              </el-select>
+              <el-select v-else v-model="spikeType" class="el-select-wide">
+                <el-option label="Up" value="up" />
+                <el-option label="Down" value="down" />
+                <el-option label="Both" value="both" />
+              </el-select>
+            </el-col>
 
-      <div v-if="type === 'frequency' || type === 'flatline' || type === 'spike' || type === 'new_term'">
-        <!-- native modifier has been removed, please confirm whether the function has been affected  -->
-        <el-form
-          ref="freqFlatlineOptions"
-          :model="$store.state.config.match"
-          label-position="top"
-          @submit.prevent>
-          <template v-if="type !== 'new_term'">
-            <el-form-item label="Use count query">
-              <el-switch
-                id="useCountQuery"
-                v-model="useCountQuery"
-                :disabled="useTermsQuery"
-                @update:model-value="refreshOptionsPop" />
-              <label>
-                If true, ElastAlert 2 will poll Elasticsearch using the count api,
-                and not download all of the matching documents.
-                This is useful is you care only about numbers and not the actual data.
-                It should also be used if you expect a large number of query hits, in the order of
-                tens of thousands or more.
-              </label>
+            <el-col v-if="spikeOrThreshold !== 'any'" :span="8">
+              <el-form ref="spikeOrThreshold" :model="$store.state.config.match">
+                <template v-if="spikeOrThreshold === 'is'">
+                  <el-form-item v-if="aboveOrBelow === 'above'" prop="numEvents" required>
+                    <el-input-number
+                      id="numEvents"
+                      v-model="numEvents"
+                      :min="1"
+                      class="el-input-wide"
+                      @update:model-value="validate" />
+                  </el-form-item>
+                  <el-form-item v-else prop="threshold" required>
+                    <el-input-number
+                      id="threshold"
+                      v-model="threshold"
+                      :min="1"
+                      class="el-input-wide"
+                      @update:model-value="validate" />
+                  </el-form-item>
+                </template>
+                <el-form-item v-else prop="spikeHeight" required>
+                  <el-input-number
+                    id="spikeHeight"
+                    v-model="spikeHeight"
+                    class="el-input-wide"
+                    @update:model-value="validate" />
+                </el-form-item>
+              </el-form>
+            </el-col>
+          </el-row>
+        </div>
+
+        <div v-else>
+          <el-form
+            ref="minMaxThreshold"
+            :rules="minMaxThresholdRules"
+            :model="$store.state.config.match"
+            label-width="60px">
+            <el-form-item label="Above" prop="maxThreshold">
+              <el-input-number id="maxThreshold" v-model="maxThreshold" :min="1" @change="validate" />
             </el-form-item>
+            <el-form-item label="Below" prop="minThreshold">
+              <el-input-number id="minThreshold" v-model="minThreshold" :min="1" @change="validate" />
+            </el-form-item>
+          </el-form>
+        </div>
+      </el-popover>
+    </span>
+
+    <span v-show="showTime">
+      <span v-show="metricAggType === 'count' || metricAggType === 'field changes' || metricAggType === 'cardinality' || metricAggType === 'avg' || metricAggType === 'sum' || metricAggType === 'min' || metricAggType === 'max'">
+        <el-popover
+          popper-class="popover-time">
+          <template #reference>
+            <span class="pop-trigger">
+              <span>
+                <span v-if="metricAggType === 'field changes'">
+                  WITHIN
+                  <span v-if="!useTimeframe">ANY TIMEFRAME</span>
+                </span>
+                <span v-if="metricAggType === 'count' || metricAggType === 'cardinality' || metricAggType === 'avg' || metricAggType === 'sum' || metricAggType === 'min' || metricAggType === 'max'">FOR </span>
+                <span v-if="useTimeframe">THE LAST</span>
+              </span>
+              <ElastalertTimeView
+                v-if="useTimeframe"
+                :time="timeframe" />
+            </span>
           </template>
 
-          <el-form-item v-if="type !== 'spike'" :class="{ 'm-n-sm': type === 'new_term' }" label="Use terms query">
-            <el-switch v-model="useTermsQuery" :disabled="useCountQuery" @update:model-value="refreshOptionsPop" />
-            <label v-if="type === 'new_term'">
-              If true, ElastAlert 2 will use aggregation queries to get terms instead of regular search queries.
-              This is faster than regular searching if there is a large number of documents.
-              <span v-if="useTermsQuery">
-                When using use_terms_query, make sure that the field you are using is not analyzed.
-                If it is, the results of each terms query may return tokens rather than full values.
-                ElastAlert 2 will by default turn on use_keyword_postfix, which attempts to use the non-analyzed version
-                (.keyword or .raw) to gather initial terms. These will not match the partial values and result
-                in false positives.
-              </span>
-            </label>
-            <label v-else>
-              If true, ElastAlert 2 will make an aggregation query against Elasticsearch
-              to get counts of documents matching each unique value of "query key". This
-              must be used with "query key" and "doc type". This will only return a maximum
-              of "terms size", default 50, unique terms.
-            </label>
-          </el-form-item>
+          <el-form v-if="metricAggType === 'field changes'" :class="{ 'm-s-lg': useTimeframe }">
+            <el-form-item label="Limit timeframe">
+              <el-switch v-model="useTimeframe" />
+              <label>
+                By default, the change rule type has no maximum time limit between changes.
+                Enable this option to check for a change within a limited time window.
+              </label>
+            </el-form-item>
+          </el-form>
 
-          <el-form-item
-            v-if="useCountQuery || useTermsQuery"
-            label="Doc type"
-            prop="docType"
-            required>
-            <el-select
-              id="docType"
-              v-model="docType"
-              filterable
-              clearable
-              allow-create
-              placeholder=""
-              @change="validateFreqFlatlineOptions">
-              <el-option v-for="type2 in types" :key="type2" :label="type2" :value="type2" />
-            </el-select>
-            <label>
-              Specify the _type of document to search for.
-              This must be present if "use count query" or "use terms query" is set.
+          <span v-if="useTimeframe">
+            <ElastalertTimePicker
+              id="timeframe"
+              :unit="Object.keys(timeframe)[0]"
+              :amount="Object.values(timeframe)[0]"
+              @update:model-value="updateTimeframe" />
+            <label v-if="metricAggType === 'field changes'">
+              The maximum time between changes.
+              After this time period, elastalert will forget the old
+              value of the {{ compareKey }} field.
             </label>
-          </el-form-item>
+          </span>
+        </el-popover>
+      </span>
 
-          <el-form-item v-if="useTermsQuery" label="Terms size">
-            <el-input-number v-model="termsSize" />
-            <label v-if="type === 'new_term'">
-              This means that if a new term appears but there are at least this many terms which
-              appear more frequently, it will not be found. Default is 50.
-            </label>
-            <label v-else>
-              When used with "use terms query", this is the maximum number of terms returned
-              per query. Default is 50.
-            </label>
-          </el-form-item>
+      <span v-show="showForTheLast">
+        <el-popover>
+          <template #reference>
+            <span class="pop-trigger-pseudo">
+              <span>FOR THE LAST </span>
+              <ElastalertTimeView :time="bufferTime" />
+            </span>
+          </template>
+        </el-popover>
+      </span>
+    </span>
 
-          <el-form-item label="Use keyword postfix">
-            <el-switch id="useKeywordPostfix" v-model="useKeywordPostfix" />
-            <label>
-              If true, ElastAlert 2 will automatically try to add .keyword (ES5+) or
-              .raw to the fields when making an initial query.
-              These are non-analyzed fields added by Logstash.
-              If the field used is analyzed, the initial query will return only the tokenized values,
-              potentially causing false positives. Defaults to true.
-            </label>
-          </el-form-item>
-        </el-form>
-      </div>
+    <span v-if="showOptions">
+      <el-popover
+        ref="optionsPop"
+        v-model="popOptionsVisible"
+        :class="{ 'is-invalid': !popOptionsValid }"
+        popper-class="popover-options">
+        <template #reference>
+          <span class="pop-trigger">
+            <span>WITH OPTIONS</span>
+          </span>
+        </template>
 
-      <div v-if="type === 'spike'">
-        <!-- native modifier has been removed, please confirm whether the function has been affected  -->
-        <el-form
-          :model="$store.state.config.match"
-          label-position="top"
-          class="m-n-lg"
-          @submit.prevent>
-          <el-form-item label="Threshold (reference)" prop="thresholdRef">
-            <el-input-number v-model="thresholdRef" />
-            <label>
-              The minimum number of events that must exist in the
-              reference window for an alert to trigger.
-              For example, if "spike height" is 3 and "threshold reference" is 10,
-              then the ‘reference’ window must contain
-              at least 10 events and the ‘current’ window at least
-              30 events for an alert to be triggered.
-            </label>
-          </el-form-item>
+        <div v-if="metricAggType === 'field not in list' || metricAggType === 'field changes'">
+          <!-- native modifier has been removed, please confirm whether the function has been affected  -->
+          <el-form
+            ref="form"
+            :model="$store.state.config.match"
+            label-position="top"
+            @submit.prevent>
+            <el-form-item label="Ignore null">
+              <el-switch v-model="ignoreNull" />
+              <label>If set, events without the selected field will not match.</label>
+            </el-form-item>
+          </el-form>
+        </div>
 
-          <el-form-item label="Threshold (current)" prop="thresholdCur">
-            <el-input-number v-model="thresholdCur" />
-            <label>
-              The minimum number of events that must exist in the current
-              window for an alert to trigger.
-              For example, if 'spike height' is 3 and 'threshold current' is 60, then an alert
-              will occur if the current window has more than 60 events and the reference
-              window has less than 20.
-            </label>
-          </el-form-item>
-        </el-form>
-      </div>
-    </el-popover>
+        <div v-if="metricAggType === 'new term'">
+          <!-- native modifier has been removed, please confirm whether the function has been affected  -->
+          <el-form
+            ref="form"
+            :model="$store.state.config.match"
+            label-position="top"
+            @submit.prevent>
+            <el-form-item label="Terms window">
+              <ElastalertTimePicker
+                id="termsWindowSize"
+                :unit="Object.keys(termsWindowSize)[0]"
+                :amount="Object.values(termsWindowSize)[0]"
+                @update:model-value="updateTermsWindowSize" />
+              <label>
+                The amount of time used for the initial query to find existing terms.
+                No term that has occurred within this time frame will trigger an alert.
+                The default is 30 days.
+              </label>
+            </el-form-item>
+
+            <el-form-item label="Window step">
+              <ElastalertTimePicker
+                id="windowStepSize"
+                :unit="Object.keys(windowStepSize)[0]"
+                :amount="Object.values(windowStepSize)[0]"
+                @update:model-value="updateWindowStepSize" />
+              <label>
+                When querying for existing terms, split up the time range into steps of this size.
+                For example, using the default 30 day window size, and the default 1 day step size,
+                30 invidivdual queries will be made.
+                This helps to avoid timeouts for very expensive aggregation queries.
+                The default is 1 day.
+              </label>
+            </el-form-item>
+
+            <el-form-item label="Alert on missing field">
+              <el-switch v-model="alertOnMissingField" />
+              <label>Whether or not to alert when a field is missing from a document.</label>
+            </el-form-item>
+          </el-form>
+        </div>
+
+        <div v-if="type === 'frequency' || type === 'flatline' || type === 'spike' || type === 'new_term'">
+          <!-- native modifier has been removed, please confirm whether the function has been affected  -->
+          <el-form
+            ref="freqFlatlineOptions"
+            :model="$store.state.config.match"
+            label-position="top"
+            @submit.prevent>
+            <template v-if="type !== 'new_term'">
+              <el-form-item label="Use count query">
+                <el-switch
+                  id="useCountQuery"
+                  v-model="useCountQuery"
+                  :disabled="useTermsQuery"
+                  @update:model-value="refreshOptionsPop" />
+                <label>
+                  If true, ElastAlert 2 will poll Elasticsearch using the count api,
+                  and not download all of the matching documents.
+                  This is useful is you care only about numbers and not the actual data.
+                  It should also be used if you expect a large number of query hits, in the order of
+                  tens of thousands or more.
+                </label>
+              </el-form-item>
+            </template>
+
+            <el-form-item v-if="type !== 'spike'" :class="{ 'm-n-sm': type === 'new_term' }" label="Use terms query">
+              <el-switch v-model="useTermsQuery" :disabled="useCountQuery" @update:model-value="refreshOptionsPop" />
+              <label v-if="type === 'new_term'">
+                If true, ElastAlert 2 will use aggregation queries to get terms instead of regular search queries.
+                This is faster than regular searching if there is a large number of documents.
+                <span v-if="useTermsQuery">
+                  When using use_terms_query, make sure that the field you are using is not analyzed.
+                  If it is, the results of each terms query may return tokens rather than full values.
+                  ElastAlert 2 will by default turn on use_keyword_postfix, which attempts to use the non-analyzed version
+                  (.keyword or .raw) to gather initial terms. These will not match the partial values and result
+                  in false positives.
+                </span>
+              </label>
+              <label v-else>
+                If true, ElastAlert 2 will make an aggregation query against Elasticsearch
+                to get counts of documents matching each unique value of "query key". This
+                must be used with "query key" and "doc type". This will only return a maximum
+                of "terms size", default 50, unique terms.
+              </label>
+            </el-form-item>
+
+            <el-form-item
+              v-if="useCountQuery || useTermsQuery"
+              label="Doc type"
+              prop="docType"
+              required>
+              <el-select
+                id="docType"
+                v-model="docType"
+                filterable
+                clearable
+                allow-create
+                placeholder=""
+                @change="validateFreqFlatlineOptions">
+                <el-option v-for="type2 in types" :key="type2" :label="type2" :value="type2" />
+              </el-select>
+              <label>
+                Specify the _type of document to search for.
+                This must be present if "use count query" or "use terms query" is set.
+              </label>
+            </el-form-item>
+
+            <el-form-item v-if="useTermsQuery" label="Terms size">
+              <el-input-number v-model="termsSize" />
+              <label v-if="type === 'new_term'">
+                This means that if a new term appears but there are at least this many terms which
+                appear more frequently, it will not be found. Default is 50.
+              </label>
+              <label v-else>
+                When used with "use terms query", this is the maximum number of terms returned
+                per query. Default is 50.
+              </label>
+            </el-form-item>
+
+            <el-form-item label="Use keyword postfix">
+              <el-switch id="useKeywordPostfix" v-model="useKeywordPostfix" />
+              <label>
+                If true, ElastAlert 2 will automatically try to add .keyword (ES5+) or
+                .raw to the fields when making an initial query.
+                These are non-analyzed fields added by Logstash.
+                If the field used is analyzed, the initial query will return only the tokenized values,
+                potentially causing false positives. Defaults to true.
+              </label>
+            </el-form-item>
+          </el-form>
+        </div>
+
+        <div v-if="type === 'spike'">
+          <!-- native modifier has been removed, please confirm whether the function has been affected  -->
+          <el-form
+            :model="$store.state.config.match"
+            label-position="top"
+            class="m-n-lg"
+            @submit.prevent>
+            <el-form-item label="Threshold (reference)" prop="thresholdRef">
+              <el-input-number v-model="thresholdRef" />
+              <label>
+                The minimum number of events that must exist in the
+                reference window for an alert to trigger.
+                For example, if "spike height" is 3 and "threshold reference" is 10,
+                then the ‘reference’ window must contain
+                at least 10 events and the ‘current’ window at least
+                30 events for an alert to be triggered.
+              </label>
+            </el-form-item>
+
+            <el-form-item label="Threshold (current)" prop="thresholdCur">
+              <el-input-number v-model="thresholdCur" />
+              <label>
+                The minimum number of events that must exist in the current
+                window for an alert to trigger.
+                For example, if 'spike height' is 3 and 'threshold current' is 60, then an alert
+                will occur if the current window has more than 60 events and the reference
+                window has less than 20.
+              </label>
+            </el-form-item>
+          </el-form>
+        </div>
+      </el-popover>
+    </span>
 
     <el-alert
       v-if="bigBuckets && !useCountQuery && metricAggType === 'count' && spikeOrThreshold !== 'any'"

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,12 @@
 import { createApp } from 'vue';
 import ElementPlus, { ElNotification } from 'element-plus';
+
+const originalWarn = console.warn;
+console.warn = (...args) => {
+  if (args[0] && args[0].toString().includes('ElInfiniteScroll')) return;
+  originalWarn(...args);
+};
+
 import axios from 'axios';
 import WebSocketPlugin from './plugins/websocket';
 import VueJsonPretty from 'vue-json-pretty';

--- a/src/router.js
+++ b/src/router.js
@@ -45,7 +45,7 @@ const router = createRouter({
       component: Rules
     },
     {
-      path: '/folders/:type/:path*',
+      path: '/folders/:type/:path(.*)',
       name: 'folder',
       component: Folder,
       props: route => ({ ...route.params, ...route.query })

--- a/src/views/RuleView.vue
+++ b/src/views/RuleView.vue
@@ -290,7 +290,7 @@ export default {
   props: ['id'],
   data() {
     return {
-      activeTab:'overview',
+      activeTab: 'overview',
       loaded: false,
       silencePopoverVisible: false,
       now: new Date(),

--- a/src/views/RuleView.vue
+++ b/src/views/RuleView.vue
@@ -47,7 +47,7 @@
         <router-link
           :to="{
             name: 'ruleconfigeditor',
-            params: { action: 'edit', path: id },
+            params: { path: id },
           }">
           <el-button plain type="primary">
             <el-icon><Edit /></el-icon>

--- a/src/views/RuleView.vue
+++ b/src/views/RuleView.vue
@@ -152,7 +152,7 @@
 
       <br>
 
-      <el-tabs type="card" class="m-n-sm">
+      <el-tabs type="card" class="m-n-sm" v-model="activeTab">
         <el-tab-pane label="Overview" name="overview">
           <template
             v-if="
@@ -290,6 +290,7 @@ export default {
   props: ['id'],
   data() {
     return {
+      activeTab:'overview',
       loaded: false,
       silencePopoverVisible: false,
       now: new Date(),

--- a/src/views/TemplateView.vue
+++ b/src/views/TemplateView.vue
@@ -32,7 +32,6 @@
         <router-link
           :to="{
             name: 'ruleconfigbuilder',
-            params: { action: 'add' },
             query: { prefill: id },
           }">
           <el-button plain type="primary">
@@ -44,7 +43,7 @@
         <router-link
           :to="{
             name: 'templateconfigeditor',
-            params: { action: 'edit', path: id },
+            params: { path: id },
           }">
           <el-button type="primary" plain>
             <el-icon><Edit /></el-icon>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,10 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
 import AutoImport from 'unplugin-auto-import/vite'
 import Components from 'unplugin-vue-components/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
-import { loadEnv } from 'vite'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
@@ -64,31 +63,52 @@ export default defineConfig(({ mode }) => {
     chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {
-        manualChunks: {
-          // Vue3
-          'vue-vendor': ['vue', 'vue-router'],
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return
+
+          // Vue
+          if (id.includes('vue-router')) return 'vue-router'
+          if (id.includes('vue')) return 'vue'
 
           // Element Plus
-          'element-plus': ['element-plus'],
+          if (id.includes('element-plus')) return 'element-plus'
 
           // Charts
-          'charts': ['echarts', 'vue-echarts', 'zrender'],
+          if (
+            id.includes('echarts') ||
+            id.includes('vue-echarts') ||
+            id.includes('zrender')
+          ) {
+            return 'charts'
+          }
 
           // Utils
-          'utils': [
-            'axios', 'lodash.clonedeep', 'lodash.get', 'lodash.throttle',
-            'dayjs', 'js-yaml', 'validator', 'semver', 'change-case'
-          ],
+          if (
+            id.includes('axios') ||
+            id.includes('lodash') ||
+            id.includes('dayjs') ||
+            id.includes('js-yaml') ||
+            id.includes('validator') ||
+            id.includes('semver') ||
+            id.includes('change-case')
+          ) {
+            return 'utils'
+          }
 
-          'editor': ['prismjs', 'vue-prism-component'],
+          // Editor
+          if (
+            id.includes('prismjs') ||
+            id.includes('vue-prism-component')
+          ) {
+            return 'editor'
+          }
 
-          'icons': [
-            '@fortawesome/fontawesome-svg-core',
-            '@fortawesome/free-solid-svg-icons',
-            '@fortawesome/free-regular-svg-icons',
-            '@fortawesome/free-brands-svg-icons',
-            '@fortawesome/vue-fontawesome'
-          ]
+          // FontAwesome
+          if (id.includes('@fortawesome')) {
+            return 'icons'
+          }
+
+          return 'vendor'
         }
       }
     }


### PR DESCRIPTION
- バージョンアップ対応

  - Vue Router
  - Vite

- vue3対応
  - Element Plusのel-tabsで、初期値を明示的に管理する修正
  - Vue Router 4.1.4以降の仕様変更に伴うparamsの整理
  - vue3のマルチルート要素におけるディレクティブ警告修正
  - v-infinite-scrollの警告対応（暫定対応）
 